### PR TITLE
Remove abstract from tags

### DIFF
--- a/checklists/design-handoff.md
+++ b/checklists/design-handoff.md
@@ -2,7 +2,7 @@
 title: Design Handoff
 category: Design
 date: "2020-03-09"
-tags: ['abstract', 'exportables', 'tools', 'style-guide', 'consistency', 'handoff']
+tags: ['exportables', 'tools', 'style-guide', 'consistency', 'handoff']
 description: A good handoff makes development process smoother. Well, at least for the beginning... This checklist makes sure that we don't miss anything on the handoff.
 ---
 

--- a/checklists/design-handoff.md
+++ b/checklists/design-handoff.md
@@ -2,7 +2,7 @@
 title: Design Handoff
 category: Design
 date: "2020-03-09"
-tags: ['exportables', 'tools', 'style-guide', 'consistency', 'handoff']
+tags: ['tools', 'style-guide', 'consistency', 'handoff']
 description: A good handoff makes development process smoother. Well, at least for the beginning... This checklist makes sure that we don't miss anything on the handoff.
 ---
 


### PR DESCRIPTION
I believe adding abstract as a tag wasn't necessary since the checklist already has #tools tag. Open to discussion.