### PR TITLE
Add WOSPM checklist

### DIFF
--- a/checklists/wospm-checlist.md
+++ b/checklists/wospm-checlist.md
@@ -12,7 +12,7 @@ description: A checklist by WOSPM organization for project owners to measure the
 - [ ] Project has a README file.
 - [ ] Project has a LICENSE.
 - [ ] Project has a CONTRIBUTING file.
-- [ ] Project has a CODE_OF_CONDUCT file.
+- [ ] Project has a CODE\_OF\_CONDUCT file.
 
 ### README
 

--- a/checklists/wospm-checlist.md
+++ b/checklists/wospm-checlist.md
@@ -39,9 +39,9 @@ description: A checklist by WOSPM organization for project owners to measure the
 ### Code of Conduct
 
 - [ ] CODE_OF_CONDUCT explains where the code of conduct takes effect.
-- [ ] CODE_OF_CONDUCT explains whom the code of conduct applies to.
-- [ ] CODE_OF_CONDUCT explains what happens if someone violates the code of conduct.
-- [ ] CODE_OF_CONDUCT explains how someone can report violations.
+- [ ] CODE\_\OF_CONDUCT explains whom the code of conduct applies to.
+- [ ] CODE\_OF\_CONDUCT explains what happens if someone violates the code of conduct.
+- [ ] CODE\_OF\_CONDUCT explains how someone can report violations.
 
 ### If your project is on GitHub
 

--- a/checklists/wospm-checlist.md
+++ b/checklists/wospm-checlist.md
@@ -3,7 +3,7 @@ title: WOSPM Checklist
 category: "General"
 date: "2020-03-23"
 tags: ['open-source', 'open-source-maintainers']
-description: A checklist by [WOSPM](https://wospm.info/) organization for project owners to measure their open source project if it is a welcoming project or not. The checklist is created based on the [Open Source Guides](https://opensource.guide/).
+description: A checklist by WOSPM organization for project owners to measure their open source project if it is a welcoming project or not. The checklist is created based on the Open Source Guides.
 ---
 
 ### Basic

--- a/checklists/wospm-checlist.md
+++ b/checklists/wospm-checlist.md
@@ -1,0 +1,52 @@
+---
+title: WOSPM Checklist
+category: "General"
+date: "2020-03-23"
+tags: ['open-source', 'open-source-maintainers']
+description: A checklist by [WOSPM](https://wospm.info/) organization for project owners to measure their open source project if it is a welcoming project or not. The checklist is created based on the [Open Source Guides](https://opensource.guide/).
+---
+
+### Basic
+
+- [ ] Project is public.
+- [ ] Project has a README file.
+- [ ] Project has a LICENSE.
+- [ ] Project has a CONTRIBUTING file.
+- [ ] Project has a CODE_OF_CONDUCT file.
+
+### README
+
+- [ ] README explains what this project does.
+- [ ] README explains why this project is useful.
+- [ ] README explains how to install.
+- [ ] README explains how users get started.
+- [ ] README has link to CONTRIBUTING file.
+- [ ] README has link to CODE_OF_CONDUCT file.
+- [ ] README explains where the users can get help when needed.
+- [ ] README has a table of contents (ToC) at very top of the file.
+
+### CONTRIBUTING
+
+- [ ] CONTRIBUTING is in the root directory.
+- [ ] CONTRIBUTING has a welcome message.
+- [ ] CONTRIBUTING explains the types of contributions requested.
+- [ ] CONTRIBUTING explains how to set up the environments and run tests.
+- [ ] CONTRIBUTING explains how to suggest a new feature.
+- [ ] CONTRIBUTING explains how to file a bug report.
+- [ ] CONTRIBUTING has a table of contents (ToC) at very top of the file.
+- [ ] CONTRIBUTING has style guides (coding conventions) written.
+
+### Code of Conduct
+
+- [ ] CODE_OF_CONDUCT explains where the code of conduct takes effect.
+- [ ] CODE_OF_CONDUCT explains whom the code of conduct applies to.
+- [ ] CODE_OF_CONDUCT explains what happens if someone violates the code of conduct.
+- [ ] CODE_OF_CONDUCT explains how someone can report violations.
+
+### If your project is on GitHub
+
+- [ ] Project has a short description on version control system (e.g. description on Github).
+- [ ] Related topics are added to the repository.
+- [ ] Labels are used to highlight the issues ('good first issue' for beginners etc.).
+- [ ] Pull request template is created.
+- [ ] Issue template(s) is/are created.

--- a/checklists/wospm-checlist.md
+++ b/checklists/wospm-checlist.md
@@ -38,8 +38,8 @@ description: A checklist by WOSPM organization for project owners to measure the
 
 ### Code of Conduct
 
-- [ ] CODE_OF_CONDUCT explains where the code of conduct takes effect.
-- [ ] CODE\_\OF_CONDUCT explains whom the code of conduct applies to.
+- [ ] CODE\_OF\_CONDUCT explains where the code of conduct takes effect.
+- [ ] CODE\_OF\_CONDUCT explains whom the code of conduct applies to.
 - [ ] CODE\_OF\_CONDUCT explains what happens if someone violates the code of conduct.
 - [ ] CODE\_OF\_CONDUCT explains how someone can report violations.
 

--- a/checklists/wospm-checlist.md
+++ b/checklists/wospm-checlist.md
@@ -21,7 +21,7 @@ description: A checklist by WOSPM organization for project owners to measure the
 - [ ] README explains how to install.
 - [ ] README explains how users get started.
 - [ ] README has link to CONTRIBUTING file.
-- [ ] README has link to CODE_OF_CONDUCT file.
+- [ ] README has link to CODE\_OF\_CONDUCT file.
 - [ ] README explains where the users can get help when needed.
 - [ ] README has a table of contents (ToC) at very top of the file.
 


### PR DESCRIPTION
A checklist by [WOSPM](https://wospm.info/) organization for project owners to measure their open source project if it is a welcoming project or not. The checklist is created based on the [Open Source Guides](https://opensource.guide/).